### PR TITLE
feat(monitoring): add Prometheus + Grafana monitoring stack

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -140,7 +140,7 @@ jobs:
           username: ${{ secrets.SSH_USER }}
           password: ${{ secrets.SSH_PASSWORD }}
           port: ${{ secrets.SSH_PORT || 22 }}
-          source: "docker-compose.prod.yml,initdb.d"
+          source: "docker-compose.prod.yml,initdb.d,monitoring"
           target: "/data/workspace/open-wes/"
 
       - name: Deploy via SSH

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Open WES is a Warehouse Execution System. Monorepo structure:
 - `client/` — React 17, TypeScript, MobX + AMIS framework
 - Infrastructure: Docker Compose, MySQL 8.0, Redis 7.2, Nacos 2.0, Kafka
 
-**Read `server/Code Rule.md` first** — it defines DDD rules, database standards, plugin patterns, and validation rules that all backend code must follow.
+**Read `docs/standards/backend.md` first** — it defines DDD rules, database standards, plugin patterns, and validation rules that all backend code must follow.
 
 ## Project Structure
 
@@ -220,7 +220,7 @@ All schema and data changes **must** use Liquibase changelogs — never ad-hoc S
 
 | Purpose | Path |
 |---------|------|
-| Backend coding standards | `server/Code Rule.md` |
+| Backend coding standards | `docs/standards/backend.md` |
 | Frontend standards (detailed) | `docs/standards/frontend.md` |
 | Repository hygiene standards | `docs/standards/repository.md` |
 | Database migration standards | `docs/standards/liquibase.md` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,13 +21,13 @@ modules-gateway/      # API gateway
 modules-plugin/       # Plugin implementations
 modules-search/       # Search functionality
 modules-api-platform/ # External API platform
-modules-utils/        # Shared utilities (must NOT depend on other modules)
+modules-utils/        # Shared utilities (must NOT depend on other modules) — includes monitoring module
 server/               # Spring Boot runners (wes-server, station-server, gateway-server)
 ```
 
 ### Client (`client/src/`)
 ```
-pages/        # Page components (wms/, api_platform/, data_platform/, user/)
+pages/        # Page components (wms/, api_platform/, data_platform/, user/, monitoring/)
 components/   # Shared React components
 stores/       # MobX state tree stores
 routes/       # React Router config + lazy-loaded route mapping
@@ -125,6 +125,53 @@ These rules are non-negotiable:
 7. **Always** use parameterized queries for any user-influenced SQL.
 8. Store tokens with expiry handling. Prefer httpOnly cookies over localStorage for sensitive tokens.
 
+## Monitoring & Observability
+
+The project uses Prometheus + Grafana + Loki for monitoring, alerting, and log aggregation.
+
+### Architecture
+- **Metrics**: Application (Micrometer) → `/actuator/prometheus` → Prometheus scrape → Grafana
+- **Logs**: Application log files → Promtail → Loki → Grafana
+- **Alerts**: Prometheus/Loki alert rules → AlertManager → Webhook
+- **Infrastructure**: MySQL/Redis/Node/Kafka Exporters → Prometheus
+
+### Monitoring Module (`modules-utils/monitoring/`)
+- Auto-configured via `MonitoringAutoConfiguration` (Spring Boot auto-config)
+- Business metrics use **Guava `@Subscribe`** on domain events — zero invasion of business code
+- `DomainEventProcessor` (BeanPostProcessor) auto-registers any bean with `@Subscribe` methods
+- One `*MetricsSubscriber` per domain: Inbound, Outbound, Task, Stock
+- All three servers (WES, Station, Gateway) expose `/actuator/prometheus`
+
+### Adding New Business Metrics
+1. Create a `@Component` class in `org.openwes.monitoring.metrics`
+2. Add `@Subscribe` methods for the domain events you want to track
+3. Use `MeterRegistry` to record counters/gauges/timers
+4. The subscriber is auto-registered with EventBus — no manual wiring needed
+
+### Frontend Monitoring App
+- Top-level app (`system_code='monitoring'`) with menu entries in `u_menu` table
+- Pages embed Grafana dashboards via iframe (`?kiosk` mode)
+- Grafana configured for anonymous Viewer access + iframe embedding
+
+### Monitoring Config Files
+All monitoring infrastructure config lives in `monitoring/` at the repo root:
+```
+monitoring/
+├── prometheus/          # Scrape targets + alert rules
+├── grafana/             # Dashboards + datasource provisioning
+├── loki/                # Log storage config
+├── promtail/            # Log collection config
+└── alertmanager/        # Alert routing + notification
+```
+
+### Monitoring Ports
+| Service | Port |
+|---------|------|
+| Prometheus | 9090 |
+| Grafana | 3000 |
+| Loki | 3100 |
+| AlertManager | 9093 |
+
 ## Build and Run
 
 ```bash
@@ -145,6 +192,10 @@ HOST_IP=$(hostname -I | awk '{print $1}') docker-compose up -d
 | WES Server | 9010 |
 | Station Server | 9040 |
 | Frontend | 80 |
+| Prometheus | 9090 |
+| Grafana | 3000 |
+| Loki | 3100 |
+| AlertManager | 9093 |
 
 ## Database Migrations
 
@@ -180,3 +231,7 @@ All schema and data changes **must** use Liquibase changelogs — never ad-hoc S
 | DB init scripts | `initdb.d/` |
 | Frontend entry | `client/src/index.tsx` |
 | Route definitions | `client/src/routes/path2Compoment.tsx` |
+| Monitoring module | `server/modules-utils/monitoring/` |
+| Monitoring infra config | `monitoring/` |
+| Monitoring design spec | `docs/superpowers/specs/2026-05-23-monitoring-alerting-framework-design.md` |
+| Domain event system | `server/modules-utils/domain-event/` |

--- a/client/src/locales/en-us.json
+++ b/client/src/locales/en-us.json
@@ -996,5 +996,10 @@
 
     "confirm.callContainer": "Are you sure to call container?",
 
-    "common.loading": "loading..."
+    "common.loading": "loading...",
+
+    "monitoring.overview.title": "Overview",
+    "monitoring.jvm.title": "JVM Monitoring",
+    "monitoring.business.title": "Business Metrics",
+    "monitoring.infrastructure.title": "Infrastructure"
 }

--- a/client/src/locales/en-us.json
+++ b/client/src/locales/en-us.json
@@ -998,6 +998,7 @@
 
     "common.loading": "loading...",
 
+    "monitoring.app.title": "Monitoring",
     "monitoring.overview.title": "Overview",
     "monitoring.jvm.title": "JVM Monitoring",
     "monitoring.business.title": "Business Metrics",

--- a/client/src/locales/zh-cn.json
+++ b/client/src/locales/zh-cn.json
@@ -997,6 +997,11 @@
     "dashboard.requiredQty": "需求数量",
 
     "confirm.callContainer": "确认呼叫容器？",
-    "common.loading": "加载中..."
+    "common.loading": "加载中...",
+
+    "monitoring.overview.title": "总览",
+    "monitoring.jvm.title": "JVM 监控",
+    "monitoring.business.title": "业务指标",
+    "monitoring.infrastructure.title": "基础设施"
 
 }

--- a/client/src/locales/zh-cn.json
+++ b/client/src/locales/zh-cn.json
@@ -999,6 +999,7 @@
     "confirm.callContainer": "确认呼叫容器？",
     "common.loading": "加载中...",
 
+    "monitoring.app.title": "监控中心",
     "monitoring.overview.title": "总览",
     "monitoring.jvm.title": "JVM 监控",
     "monitoring.business.title": "业务指标",

--- a/client/src/pages/monitoring/GrafanaDashboard.tsx
+++ b/client/src/pages/monitoring/GrafanaDashboard.tsx
@@ -1,0 +1,28 @@
+import React from "react"
+
+interface GrafanaDashboardProps {
+    dashboardUid: string
+    dashboardSlug: string
+}
+
+const GrafanaDashboard: React.FC<GrafanaDashboardProps> = ({
+    dashboardUid,
+    dashboardSlug
+}) => {
+    const grafanaBaseUrl = window.location.protocol + "//" + window.location.hostname + ":3000"
+    const src = `${grafanaBaseUrl}/d/${dashboardUid}/${dashboardSlug}?kiosk`
+
+    return (
+        <iframe
+            src={src}
+            style={{
+                width: "100%",
+                height: "calc(100vh - 100px)",
+                border: "none"
+            }}
+            title={dashboardSlug}
+        />
+    )
+}
+
+export default GrafanaDashboard

--- a/client/src/pages/monitoring/business.tsx
+++ b/client/src/pages/monitoring/business.tsx
@@ -1,0 +1,8 @@
+import React from "react"
+import GrafanaDashboard from "./GrafanaDashboard"
+
+const MonitoringBusiness: React.FC = () => {
+    return <GrafanaDashboard dashboardUid="openwes-business" dashboardSlug="business" />
+}
+
+export default MonitoringBusiness

--- a/client/src/pages/monitoring/infrastructure.tsx
+++ b/client/src/pages/monitoring/infrastructure.tsx
@@ -1,0 +1,8 @@
+import React from "react"
+import GrafanaDashboard from "./GrafanaDashboard"
+
+const MonitoringInfrastructure: React.FC = () => {
+    return <GrafanaDashboard dashboardUid="openwes-infra" dashboardSlug="infrastructure" />
+}
+
+export default MonitoringInfrastructure

--- a/client/src/pages/monitoring/jvm.tsx
+++ b/client/src/pages/monitoring/jvm.tsx
@@ -1,0 +1,8 @@
+import React from "react"
+import GrafanaDashboard from "./GrafanaDashboard"
+
+const MonitoringJvm: React.FC = () => {
+    return <GrafanaDashboard dashboardUid="openwes-jvm" dashboardSlug="jvm" />
+}
+
+export default MonitoringJvm

--- a/client/src/pages/monitoring/overview.tsx
+++ b/client/src/pages/monitoring/overview.tsx
@@ -1,0 +1,8 @@
+import React from "react"
+import GrafanaDashboard from "./GrafanaDashboard"
+
+const MonitoringOverview: React.FC = () => {
+    return <GrafanaDashboard dashboardUid="openwes-overview" dashboardSlug="overview" />
+}
+
+export default MonitoringOverview

--- a/client/src/routes/path2Compoment.tsx
+++ b/client/src/routes/path2Compoment.tsx
@@ -623,6 +623,44 @@ const menuRouter = [
         component: lazy(() => import("@/pages/plugin_platform/plugin_store"))
     },
 
+    // Monitoring
+    {
+        path: "/monitoring/overview",
+        name: (
+            <Translation>
+                {(t) => t("monitoring.overview.title")}
+            </Translation>
+        ),
+        component: lazy(() => import("@/pages/monitoring/overview"))
+    },
+    {
+        path: "/monitoring/jvm",
+        name: (
+            <Translation>
+                {(t) => t("monitoring.jvm.title")}
+            </Translation>
+        ),
+        component: lazy(() => import("@/pages/monitoring/jvm"))
+    },
+    {
+        path: "/monitoring/business",
+        name: (
+            <Translation>
+                {(t) => t("monitoring.business.title")}
+            </Translation>
+        ),
+        component: lazy(() => import("@/pages/monitoring/business"))
+    },
+    {
+        path: "/monitoring/infrastructure",
+        name: (
+            <Translation>
+                {(t) => t("monitoring.infrastructure.title")}
+            </Translation>
+        ),
+        component: lazy(() => import("@/pages/monitoring/infrastructure"))
+    },
+
 ]
 
 const router = menuRouter.map((item: RouterItem) => {

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -22,6 +22,8 @@ services:
     image: ${IMAGE_BASE}/gateway:${IMAGE_TAG:-latest}
     ports:
       - "8090:8090"
+    volumes:
+      - gateway-logs:/app/logs
     depends_on:
       mysql:
         condition: service_healthy
@@ -37,6 +39,8 @@ services:
     image: ${IMAGE_BASE}/station:${IMAGE_TAG:-latest}
     ports:
       - "9040:9040"
+    volumes:
+      - station-logs:/app/logs
     depends_on:
       mysql:
         condition: service_healthy
@@ -52,6 +56,8 @@ services:
     image: ${IMAGE_BASE}/wes:${IMAGE_TAG:-latest}
     ports:
       - "9010:9010"
+    volumes:
+      - wes-logs:/app/logs
     depends_on:
       mysql:
         condition: service_healthy
@@ -132,6 +138,135 @@ services:
       my-network:
         aliases:
           - nacos.openwes.com
+
+  # --- Monitoring Stack ---
+  prometheus:
+    container_name: prometheus
+    image: prom/prometheus:latest
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+      - ./monitoring/prometheus/alert-rules.yml:/etc/prometheus/alert-rules.yml
+      - prometheus-data:/prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.retention.time=15d"
+    mem_limit: 512m
+    networks:
+      - my-network
+
+  grafana:
+    container_name: grafana
+    image: grafana/grafana:latest
+    ports:
+      - "3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
+    volumes:
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning
+      - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards
+      - grafana-data:/var/lib/grafana
+    mem_limit: 256m
+    depends_on:
+      - prometheus
+    networks:
+      - my-network
+
+  loki:
+    container_name: loki
+    image: grafana/loki:latest
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./monitoring/loki/loki-config.yml:/etc/loki/local-config.yaml
+      - loki-data:/loki
+    command: -config.file=/etc/loki/local-config.yaml
+    mem_limit: 768m
+    networks:
+      - my-network
+
+  promtail:
+    container_name: promtail
+    image: grafana/promtail:latest
+    volumes:
+      - ./monitoring/promtail/promtail-config.yml:/etc/promtail/config.yml
+      - wes-logs:/var/log/wes:ro
+      - station-logs:/var/log/station:ro
+      - gateway-logs:/var/log/gateway:ro
+    command: -config.file=/etc/promtail/config.yml
+    mem_limit: 128m
+    depends_on:
+      - loki
+    networks:
+      - my-network
+
+  alertmanager:
+    container_name: alertmanager
+    image: prom/alertmanager:latest
+    ports:
+      - "9093:9093"
+    volumes:
+      - ./monitoring/alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml
+    mem_limit: 64m
+    networks:
+      - my-network
+
+  node-exporter:
+    container_name: node-exporter
+    image: prom/node-exporter:latest
+    ports:
+      - "9100:9100"
+    mem_limit: 64m
+    networks:
+      - my-network
+
+  mysql-exporter:
+    container_name: mysql-exporter
+    image: prom/mysqld-exporter:latest
+    ports:
+      - "9104:9104"
+    environment:
+      DATA_SOURCE_NAME: "root:root@(mysql:3306)/"
+    depends_on:
+      mysql:
+        condition: service_healthy
+    mem_limit: 64m
+    networks:
+      - my-network
+
+  redis-exporter:
+    container_name: redis-exporter
+    image: oliver006/redis_exporter:latest
+    ports:
+      - "9121:9121"
+    environment:
+      REDIS_ADDR: "redis:6379"
+    depends_on:
+      redis:
+        condition: service_healthy
+    mem_limit: 64m
+    networks:
+      - my-network
+
+  kafka-exporter:
+    container_name: kafka-exporter
+    image: danielqsj/kafka-exporter:latest
+    ports:
+      - "9308:9308"
+    command: ["--kafka.server=kafka:9092"]
+    mem_limit: 64m
+    networks:
+      - my-network
+
+volumes:
+  wes-logs:
+  station-logs:
+  gateway-logs:
+  prometheus-data:
+  grafana-data:
+  loki-data:
 
 networks:
   my-network:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -164,6 +164,9 @@ services:
     environment:
       GF_SECURITY_ADMIN_USER: admin
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
+      GF_SECURITY_ALLOW_EMBEDDING: "true"
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Viewer
     volumes:
       - ./monitoring/grafana/provisioning:/etc/grafana/provisioning
       - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,8 @@ services:
       target: gateway
     ports:
       - "8090:8090"
+    volumes:
+      - gateway-logs:/app/logs
     depends_on:
       mysql:
         condition: service_healthy
@@ -44,6 +46,8 @@ services:
       target: station
     ports:
       - "9040:9040"
+    volumes:
+      - station-logs:/app/logs
     depends_on:
       mysql:
         condition: service_healthy
@@ -62,6 +66,8 @@ services:
       target: wes
     ports:
       - "9010:9010"
+    volumes:
+      - wes-logs:/app/logs
     depends_on:
       mysql:
         condition: service_healthy
@@ -146,6 +152,135 @@ services:
       my-network:
         aliases:
           - nacos.openwes.com
+
+  # --- Monitoring Stack ---
+  prometheus:
+    container_name: prometheus
+    image: prom/prometheus:latest
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+      - ./monitoring/prometheus/alert-rules.yml:/etc/prometheus/alert-rules.yml
+      - prometheus-data:/prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.retention.time=15d"
+    mem_limit: 512m
+    networks:
+      - my-network
+
+  grafana:
+    container_name: grafana
+    image: grafana/grafana:latest
+    ports:
+      - "3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
+    volumes:
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning
+      - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards
+      - grafana-data:/var/lib/grafana
+    mem_limit: 256m
+    depends_on:
+      - prometheus
+    networks:
+      - my-network
+
+  loki:
+    container_name: loki
+    image: grafana/loki:latest
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./monitoring/loki/loki-config.yml:/etc/loki/local-config.yaml
+      - loki-data:/loki
+    command: -config.file=/etc/loki/local-config.yaml
+    mem_limit: 768m
+    networks:
+      - my-network
+
+  promtail:
+    container_name: promtail
+    image: grafana/promtail:latest
+    volumes:
+      - ./monitoring/promtail/promtail-config.yml:/etc/promtail/config.yml
+      - wes-logs:/var/log/wes:ro
+      - station-logs:/var/log/station:ro
+      - gateway-logs:/var/log/gateway:ro
+    command: -config.file=/etc/promtail/config.yml
+    mem_limit: 128m
+    depends_on:
+      - loki
+    networks:
+      - my-network
+
+  alertmanager:
+    container_name: alertmanager
+    image: prom/alertmanager:latest
+    ports:
+      - "9093:9093"
+    volumes:
+      - ./monitoring/alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml
+    mem_limit: 64m
+    networks:
+      - my-network
+
+  node-exporter:
+    container_name: node-exporter
+    image: prom/node-exporter:latest
+    ports:
+      - "9100:9100"
+    mem_limit: 64m
+    networks:
+      - my-network
+
+  mysql-exporter:
+    container_name: mysql-exporter
+    image: prom/mysqld-exporter:latest
+    ports:
+      - "9104:9104"
+    environment:
+      DATA_SOURCE_NAME: "root:root@(mysql:3306)/"
+    depends_on:
+      mysql:
+        condition: service_healthy
+    mem_limit: 64m
+    networks:
+      - my-network
+
+  redis-exporter:
+    container_name: redis-exporter
+    image: oliver006/redis_exporter:latest
+    ports:
+      - "9121:9121"
+    environment:
+      REDIS_ADDR: "redis:6379"
+    depends_on:
+      redis:
+        condition: service_healthy
+    mem_limit: 64m
+    networks:
+      - my-network
+
+  kafka-exporter:
+    container_name: kafka-exporter
+    image: danielqsj/kafka-exporter:latest
+    ports:
+      - "9308:9308"
+    command: ["--kafka.server=kafka:9092"]
+    mem_limit: 64m
+    networks:
+      - my-network
+
+volumes:
+  wes-logs:
+  station-logs:
+  gateway-logs:
+  prometheus-data:
+  grafana-data:
+  loki-data:
 
 # Networks
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -178,6 +178,9 @@ services:
     environment:
       GF_SECURITY_ADMIN_USER: admin
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
+      GF_SECURITY_ALLOW_EMBEDDING: "true"
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Viewer
     volumes:
       - ./monitoring/grafana/provisioning:/etc/grafana/provisioning
       - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards

--- a/docs/standards/backend.md
+++ b/docs/standards/backend.md
@@ -1,15 +1,32 @@
-Here's the updated file with the new section on Configuration:
-
 # Coding Standards and Best Practices
 
 These are a set of coding standards and best practices to be followed during development. They cover various aspects, including code design, database design, validation, and testing. The main goals are to promote consistency, maintainability, and best practices across the codebase.
+
+## Table of Contents
+
+- [Code Rules](#code-rules)
+  - [Transaction](#transaction)
+  - [Error Definition](#error-definition)
+  - [Utils Usage](#utils-usage)
+  - [Domain Entity](#domain-entity)
+  - [Domain Service](#domain-service)
+  - [Domain Aggregate](#domain-aggregate)
+  - [Domain Repository](#domain-repository)
+  - [Domain Events](#domain-events)
+  - [API Implementation](#api-implementation)
+  - [Server](#server)
+- [Database Rules](#database-rules)
+- [Validation Rules](#validation-rules)
+- [Plugin Rules](#plugin-rules)
+- [Unit Test Rules](#unit-test-rules)
+- [Logging and Configuration](#logging-and-configuration)
 
 ## Code Rules
 
 ### Transaction
 
 1. **Avoid Big Transactions, Use Asynchronous and Eventually Consistent Approach**: Big transactions can lead to performance issues and potential deadlocks. Instead, use an asynchronous and eventually consistent approach to handle complex operations.
-2. **Use @Transaction Annotation Appropriately**: We only use the `@Transaction` annotation on Aggregates and repositories. Any other places should not use this annotation.
+2. **Use @Transactional Annotation Appropriately**: We only use the `@Transactional` annotation on Aggregates and repositories. Any other places should not use this annotation.
 
 ### Error Definition
 
@@ -44,7 +61,9 @@ These are a set of coding standards and best practices to be followed during dev
 
 ### Domain Entity
 
-1. **Domain Entity Immutability**: Domain entities should not have setter methods. Instead, use methods that represent the entity's state transitions. For example:
+1. **Aggregate Root**: Aggregate root entities must extend `AggregatorRoot`. This base class provides domain event publishing and optimistic locking support.
+
+2. **Domain Entity Immutability**: Domain entities should not have setter methods. Instead, use methods that represent the entity's state transitions. For example:
    ```java
    // Instead of outboundPlanOrder.setStatus(xxx);
    outboundPlanOrder.complete();
@@ -55,13 +74,13 @@ These are a set of coding standards and best practices to be followed during dev
    }
    ```
 
-2. **Domain Entity Lifecycle**: Domain entities should have methods representing their full lifecycle. For example, the `OutboundPlanOrder` class should have methods like `initialize()` to set the initial status, `preAllocate()` to change the status to `ASSIGNED`, and so on. This approach makes the entity more "alive" and encapsulates the business logic within the entity.
+3. **Domain Entity Lifecycle**: Domain entities should have methods representing their full lifecycle. For example, the `OutboundPlanOrder` class should have methods like `initialize()` to set the initial status, `preAllocate()` to change the status to `ASSIGNED`, and so on. This approach makes the entity more "alive" and encapsulates the business logic within the entity.
 
    This practice promotes a better understanding of the entity's behavior and state transitions, making it easier to maintain and extend the codebase.
 
    Example:
    ```java
-   public class OutboundPlanOrder implements Serializable {
+   public class OutboundPlanOrder extends AggregatorRoot implements Serializable {
    
        public void initialize() {
            this.outboundPlanOrderStatus = OutboundPlanOrderStatusEnum.NEW;
@@ -75,7 +94,7 @@ These are a set of coding standards and best practices to be followed during dev
    
        public void cancel() {
            log.info("outbound plan order id: {}, orderNo: {} cancel", this.id, this.orderNo);
-           if (OutboundPlanOrderStatusEnum.cancellability(this.outboundPlanOrderStatus)) {
+           if (OutboundPlanOrderStatusEnum.isCancellable(this.outboundPlanOrderStatus)) {
                this.outboundPlanOrderStatus = OutboundPlanOrderStatusEnum.CANCELED;
                this.details.forEach(OutboundPlanOrderDetail::cancel);
            }
@@ -85,7 +104,9 @@ These are a set of coding standards and best practices to be followed during dev
    }
    ```
 
-3. **String Field Length**: String type field lengths must be less than 512 characters. If you need to store more than 512 characters, use a text type and split the data into another table.
+4. **String Field Length**: String type field lengths must be no more than 512 characters. If you need to store more than 512 characters, use a text type and split the data into another table.
+
+5. **Optimistic Locking**: Use `@Version` on a version field for optimistic locking and concurrency control.
 
 ### Domain Service
 1. **Domain Service Responsibilities**: Domain services should only contain calculation logic, and they must be stateless. For example, the `OutboundWaveService` contains a function `wavePickings` that takes a list of `OutboundPlanOrder` objects as input and returns the waved `OutboundPlanOrder` objects.
@@ -96,7 +117,7 @@ These are a set of coding standards and best practices to be followed during dev
    ```
 
 ### Domain Aggregate
-1. **Domain Aggregate Usage**: Domain aggregates will aggregate multiple domain entities. If we need to update multiple entities, we should build an aggregator and use the `@Transaction` annotation to ensure data consistency. Since we use the `@Transaction` annotation, we should pull queries out to improve speed.
+1. **Domain Aggregate Usage**: Domain aggregates will aggregate multiple domain entities. If we need to update multiple entities, we should build an aggregator and use the `@Transactional` annotation to ensure data consistency. Since we use the `@Transactional` annotation, we should pull queries out to improve speed.
 
 ### Domain Repository
 1. **Domain Repository Responsibilities**:  Domain repositories should only contain find or save functions. They should not contain any update functions. For example:
@@ -113,6 +134,44 @@ containerRepository.save(container);
 ```
 2. **Function Naming**: All query functions should be named as find or findAll, and save functions should be named as save or saveAll.
 
+### Domain Events
+
+1. **Publishing Events from Entities**: Aggregate root entities publish domain events via `addAsynchronousDomainEvents()`. Events are dispatched after the transaction commits.
+   ```java
+   public void complete() {
+       this.status = COMPLETE;
+       addAsynchronousDomainEvents(new OrderCompletedEvent(this.id));
+   }
+   ```
+
+2. **Event Subscribers**: For cross-cutting concerns (e.g., metrics, audit), use Guava `@Subscribe` methods on `@Component` beans. The `DomainEventProcessor` (a `BeanPostProcessor`) auto-registers any bean with `@Subscribe` methods to the EventBus — no manual wiring needed.
+
+### API Implementation
+
+1. **Standard Annotations**: API implementation classes must use the following annotation set:
+   ```java
+   @Primary
+   @Service
+   @Validated
+   @DubboService
+   @RequiredArgsConstructor
+   public class EntityApiImpl implements IEntityApi { }
+   ```
+
+2. **Class Naming Conventions**:
+
+   | Type | Pattern | Example |
+   |------|---------|---------|
+   | API interface | `I[Entity]Api` | `IInboundPlanOrderApi` |
+   | API impl | `[Entity]ApiImpl` | `InboundPlanOrderApiImpl` |
+   | Service | `[Entity]Service` / `[Entity]ServiceImpl` | `OutboundWaveService` |
+   | Repository | `[Entity]Repository` / `[Entity]RepositoryImpl` | `ContainerRepository` |
+   | DTO | `[Entity]DTO` | `ContainerDTO` |
+   | Transfer | `[Entity]Transfer` | `InboundPlanOrderTransfer` |
+   | Error enum | `[Module]ErrorDescEnum` | `InboundErrorDescEnum` |
+
+3. **Logging**: Use `@Slf4j` (Lombok) for logger declaration. All log messages must be written in English.
+
 ### Server
 1. **Server Module Responsibilities**: The server module cannot include business codes. It should only contain common configurations and the Spring Boot starter class.
 
@@ -125,7 +184,7 @@ containerRepository.save(container);
    - Remark: 500 characters
    - Enum: 20 characters
 
-2. **POJO Class Design**: POJO classes must be designed as standard POJO classes, meaning they should not contain any special types or special database-specific configurations. For example:
+2. **POJO Class Design**: POJO classes must be designed as standard POJO classes, meaning they should not contain any special types or special database-specific configurations. Use `@Comment` for column comments (comments may be in Chinese for domain terminology).
 
    Instead of:
    ```java
@@ -141,8 +200,6 @@ containerRepository.save(container);
    ```
 
    This approach separates the database-specific configurations from the POJO class, promoting better maintainability and portability of the code.
-
-3. **Version Control for Optimistic Locking**: Add the `@Version` annotation on the POJO classes to enable optimistic locking and concurrency control.
 
 ## Validation Rules
 
@@ -172,26 +229,6 @@ containerRepository.save(container);
    ```
 
    If your parameters are objects that need validation, add `@Validated(value = ValidationSequence.class)` instead of `@Validated`, and the object needs to implement the `IValidate` interface.
-
-## Unit Test Rules
-
-1. **Test Location**: All unit tests must be written within the respective module, not in the `xxx-server` module.
-
-2. **Test Coverage**: Create unit tests for the domain layer, including entities and services. You can refer to the outbound tests as an example.
-
-3. **Avoid Starting Spring Boot**: Unit tests should avoid running the Spring Boot application.
-
-## Log Rules
-
-1. **Log Language**: All log messages must be written in English.
-
-## Configuration
-
-1. **Configuration Classification**: Configurations are divided into two main categories: Environment Configuration and Business Configuration.
-2. **Environment Configuration**: Environment configurations must be configured in Nacos.
-3. **Business Configuration**: Business configurations must be configured in the database (e.g., MySQL).
-4. **Nacos Restrictions**: Nacos cannot be used to configure any business configurations.
-
 
 ## Plugin Rules
 
@@ -249,6 +286,24 @@ public List<ContainerTask> groupContainerTasks(List<CreateContainerTaskDTO> crea
            .forEach((key, values) -> containerTasks.addAll(generateTasks(values)));
    return containerTasks;
 }
-
-
 ```
+
+## Unit Test Rules
+
+1. **Test Location**: All unit tests must be written within the respective module, not in the `xxx-server` module.
+
+2. **Test Coverage**: Create unit tests for the domain layer, including entities and services. You can refer to the outbound tests as an example.
+
+3. **Avoid Starting Spring Boot**: Unit tests should avoid running the Spring Boot application.
+
+## Logging and Configuration
+
+### Logging
+1. **Logger Declaration**: Use `@Slf4j` (Lombok) for logger declaration. Do not manually create Logger instances.
+2. **Log Language**: All log messages must be written in English.
+
+### Configuration
+1. **Configuration Classification**: Configurations are divided into two main categories: Environment Configuration and Business Configuration.
+2. **Environment Configuration**: Environment configurations must be configured in Nacos.
+3. **Business Configuration**: Business configurations must be configured in the database (e.g., MySQL).
+4. **Nacos Restrictions**: Nacos cannot be used to configure any business configurations.

--- a/docs/superpowers/specs/2026-05-23-monitoring-alerting-framework-design.md
+++ b/docs/superpowers/specs/2026-05-23-monitoring-alerting-framework-design.md
@@ -286,6 +286,18 @@ monitoring/
 3. **New `monitoring/` directory**: All monitoring configuration files
 4. **`.github/workflows/deploy.yml`**: Add `monitoring/` directory to SCP deployment
 
+### Frontend Changes (Monitoring App)
+
+1. **New `client/src/pages/monitoring/`**: Monitoring app with Grafana iframe embedding
+   - `GrafanaDashboard.tsx` — Reusable iframe component (uses `?kiosk` mode for clean embedding)
+   - `overview.tsx`, `jvm.tsx`, `business.tsx`, `infrastructure.tsx` — Individual dashboard pages
+2. **`client/src/routes/path2Compoment.tsx`**: Add 4 monitoring routes (`/monitoring/*`)
+3. **`client/src/locales/`**: Add monitoring i18n keys (en-us, zh-cn)
+4. **Liquibase changeset `db.changelog-20260523.xml`**: Insert monitoring app menu entries into `u_menu`
+   - Top-level app: `system_code='monitoring'`, ID 1300000000
+   - 4 menu items: Overview, JVM, Business, Infrastructure
+5. **Grafana Docker config**: Enable `GF_SECURITY_ALLOW_EMBEDDING`, `GF_AUTH_ANONYMOUS_ENABLED`, `GF_AUTH_ANONYMOUS_ORG_ROLE=Viewer`
+
 ### No Changes Required
 
 - Existing Logback configuration (Promtail reads log files directly)

--- a/docs/superpowers/specs/2026-05-23-monitoring-alerting-framework-design.md
+++ b/docs/superpowers/specs/2026-05-23-monitoring-alerting-framework-design.md
@@ -1,0 +1,293 @@
+# Open WES Monitoring & Alerting Framework Design
+
+## Overview
+
+Design an enterprise-grade monitoring and alerting framework for Open WES using the Prometheus + Grafana + Loki stack. The framework must be lightweight (total memory ~2GB), support scaling from single-machine Docker Compose to Kubernetes, and provide comprehensive infrastructure and business metrics with multi-channel alerting.
+
+## Current State
+
+### Existing Infrastructure
+- **SkyWalking APM Toolkit**: Logback integration only (no APM Server deployed)
+- **Spring Boot Actuator**: Enabled on wes-server only (health, info, metrics, env, scheduledtasks, threadpool)
+- **Logback**: File-based logging with rotation (DEBUG 5d, INFO 10d, ERROR 30d), SkyWalking Trace ID in log pattern
+- **Fluent Logger**: Dependency present but disabled
+- **Docker Health Checks**: Configured for MySQL, Redis, Nacos
+
+### Gaps
+- No metrics collection (Prometheus/Micrometer)
+- No visualization (Grafana)
+- No alerting system
+- No centralized log aggregation
+- No JVM/application-level performance monitoring
+- Gateway and Station servers have no Actuator endpoints
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        Grafana (Port 3000)                      │
+│            Dashboard + Alert Rule Visualization                  │
+├─────────────┬───────────────────┬───────────────────────────────┤
+│ Prometheus  │      Loki         │       AlertManager            │
+│ (Port 9090) │   (Port 3100)     │       (Port 9093)             │
+│ Metrics     │   Log Aggregation │   Alert Routing/Notification  │
+│ Storage     │   & Query         │                               │
+├─────────────┴───────────────────┴───────────────────────────────┤
+│                     Data Collection Layer                        │
+├──────────────┬──────────────┬───────────────────────────────────┤
+│ Micrometer   │  Promtail    │   Node Exporter / cAdvisor       │
+│ (In-app)     │ (Log Agent)  │   (Host/Container Metrics)       │
+├──────────────┴──────────────┴───────────────────────────────────┤
+│              Open WES Application Services                       │
+│  ┌──────────┐ ┌──────────────┐ ┌──────────────┐                │
+│  │ Gateway  │ │  WES Server  │ │Station Server│                │
+│  │  :8090   │ │    :9010     │ │    :9040     │                │
+│  └──────────┘ └──────────────┘ └──────────────┘                │
+├─────────────────────────────────────────────────────────────────┤
+│              Infrastructure                                      │
+│  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐          │
+│  │  MySQL   │ │  Redis   │ │  Nacos   │ │  Kafka   │          │
+│  │  :3306   │ │  :6379   │ │  :8848   │ │  :9092   │          │
+│  └──────────┘ └──────────┘ └──────────┘ └──────────┘          │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Data Flows
+
+1. **Metrics**: Application (Micrometer) → `/actuator/prometheus` endpoint → Prometheus scrape → Grafana display
+2. **Logs**: Application log files → Promtail collection → Loki storage → Grafana query
+3. **Alerts**: Prometheus/Loki alert rules → AlertManager → Webhook/Email/DingTalk/WeCom/Slack
+4. **Infrastructure Metrics**: MySQL Exporter, Redis Exporter, Node Exporter → Prometheus
+
+## Component Design
+
+### 1. Application Metrics Collection (Micrometer Integration)
+
+#### 1.1 New Module: `modules-utils/monitoring/`
+
+A shared monitoring module providing:
+- Micrometer Prometheus Registry auto-configuration
+- Common metrics auto-collection: JVM, thread pools, HikariCP connection pool, Dubbo RPC, Redis operations
+- Domain event-driven business metrics listeners
+
+#### 1.2 Actuator Endpoint Unification
+
+All three servers (Gateway, WES, Station) must expose:
+- `health` — with MySQL, Redis, Nacos, Kafka component health indicators
+- `prometheus` — Micrometer metrics export (new)
+- `info` — application info
+
+#### 1.3 Domain Event-Driven Business Metrics
+
+**Core approach**: Business code already publishes domain events via `addAsynchronousDomainEvents()` through Guava's `AsyncEventBus` (see `DomainEventPublisher`). The monitoring module subscribes to these events using Guava's `@Subscribe` annotation (matching the existing subscriber pattern, e.g., `AcceptOrderSubscriber`) and converts them to Micrometer metrics — zero invasion of business code.
+
+```java
+// In monitoring module — no business code changes needed
+// Uses Guava @Subscribe to match existing domain event pattern
+@Component
+@RequiredArgsConstructor
+public class InboundMetricsSubscriber {
+    private final MeterRegistry registry;
+
+    @Subscribe
+    public void onAccepted(InboundPlanOrderAcceptedEvent event) {
+        registry.counter("wes.inbound.orders.accepted.total",
+            "warehouse", event.getWarehouseCode()).increment();
+    }
+
+    @Subscribe
+    public void onCompleted(InboundOrderCompletionEvent event) {
+        registry.counter("wes.inbound.orders.completed.total").increment();
+    }
+}
+```
+
+**Important**: Metrics subscribers must be registered with the Guava `EventBus` via `DomainEventPublisher.registerSubscriber()`, not via Spring's `@EventListener` which uses a different event bus.
+
+**Architecture**:
+- One `MetricsSubscriber` per business domain: `InboundMetricsSubscriber`, `OutboundMetricsSubscriber`, `TaskMetricsSubscriber`, `StockMetricsSubscriber`, `StationMetricsSubscriber`
+- Subscribers are registered with the Guava AsyncEventBus during application startup via a `MonitoringAutoConfiguration` class
+- For metrics not driven by domain events (API latency, thread pools), use Micrometer auto-configuration + WebFilter (Gateway, which uses WebFlux) / Spring MVC Filter (WES/Station servers)
+- For Dubbo RPC metrics, integrate `dubbo-spring-boot-observability-starter` to auto-collect provider/consumer call counts and latency
+
+#### 1.4 Predefined Business Metrics
+
+| Metric Name | Type | Source | Description |
+|-------------|------|--------|-------------|
+| `wes.inbound.orders.accepted.total` | Counter | Domain Event (`InboundPlanOrderAcceptedEvent`) | Inbound orders accepted |
+| `wes.inbound.orders.completed.total` | Counter | Domain Event (`InboundOrderCompletionEvent`) | Inbound orders completed |
+| `wes.outbound.orders.total` | Counter | Domain Event | Outbound plan orders created |
+| `wes.task.processing.duration` | Timer | Domain Event | Task processing duration |
+| `wes.task.queue.size` | Gauge | Scheduled poll | Pending task queue length |
+| `wes.station.active.count` | Gauge | Scheduled poll | Active workstation count |
+| `wes.api.request.duration` | Timer | WebFilter/MVC Filter | API request latency (by route) |
+| `wes.stock.operations.total` | Counter | Domain Event | Stock operations (by type) |
+| `dubbo.provider.requests.total` | Counter | dubbo-observability | Dubbo provider call count (by service/method) |
+| `dubbo.provider.requests.duration` | Timer | dubbo-observability | Dubbo provider call latency |
+| `dubbo.consumer.requests.total` | Counter | dubbo-observability | Dubbo consumer call count |
+
+### 2. Collection Frequency & Data Retention
+
+#### Scrape Intervals
+
+| Target | Interval | Rationale |
+|--------|----------|-----------|
+| Application services (Gateway/WES/Station) | 15s | Prometheus default, balances precision and overhead |
+| Infrastructure (MySQL/Redis Exporter) | 30s | Slower change rate, reduces exporter pressure |
+| Host metrics (Node Exporter) | 30s | CPU/memory/disk don't need sub-second granularity |
+
+#### Data Retention
+- Prometheus local storage: **15 days**
+- Extensible to longer retention via Thanos/Mimir if needed
+
+### 3. Grafana Dashboards
+
+#### Default Time Ranges
+
+| Dashboard | Default Range | Default Granularity | Purpose |
+|-----------|--------------|--------------------|---------| 
+| **Real-time Operations** | Last 1 hour | 1 minute | On-duty monitoring |
+| **Business Throughput** | Last 24 hours | 1 hour | Daily peak/valley analysis |
+| **Performance Analysis** | Last 6 hours | 5 minutes | Slow request investigation |
+| **Trend Report** | Last 7 days | 1 day | Weekly capacity planning |
+
+All dashboards support user-adjustable time range and granularity via Grafana's built-in controls.
+
+#### Dashboard Contents
+
+**Overview Dashboard**: Service health status, active alerts count, key business KPIs (today's order volume, task completion rate)
+
+**JVM Dashboard**: Heap/non-heap memory, GC frequency and duration, thread count, class loading, per-service breakdown
+
+**Business Dashboard**: Inbound/outbound order volume trends, task processing rate and duration distribution, workstation utilization, stock operation trends
+
+**Infrastructure Dashboard**: MySQL connections/QPS/slow queries, Redis memory/hit rate/connections, disk/CPU/memory utilization, Kafka consumer lag
+
+### 4. Log Aggregation (Promtail + Loki)
+
+#### Collection Method
+Promtail runs as a sidecar container, mounts application log directories, and pushes to Loki.
+
+#### Log Labels
+- `job` — Service name (gateway / wes-server / station-server)
+- `level` — Log level (DEBUG / INFO / WARN / ERROR)
+- `host` — Host identifier
+
+#### Log Retention Policy
+- INFO/DEBUG: 7 days
+- WARN/ERROR: 30 days
+
+**Implementation**: Use Loki's compactor with per-stream retention rules based on the `level` label. In `loki-config.yml`, configure `retention_enabled: true` under `compactor`, and define `per_stream_rate_limits` with label matchers: `{level=~"INFO|DEBUG"}` → 7d, `{level=~"WARN|ERROR"}` → 30d. This avoids the complexity of multi-tenant setups.
+
+#### Integration with Existing Logging
+- Existing Logback file logging is preserved (local fallback)
+- Promtail reads existing log files and pushes to Loki — no changes to current logging config
+- SkyWalking Trace ID already present in logs; Loki can search by Trace ID directly
+
+### 5. Alert Rules & Notification
+
+#### 5.1 Alert Severity Levels
+
+| Level | Example Triggers | Notification | Response |
+|-------|-----------------|--------------|----------|
+| **P1 Critical** | Service down, DB unavailable, disk >95% | All channels + repeat reminders | 15 min response |
+| **P2 Warning** | CPU >80% for 5min, API latency >3s, error rate >5% | DingTalk/WeCom/Slack | 1 hour attention |
+| **P3 Info** | Disk >70%, connection pool >70%, task queue backlog | Grafana panel annotation only | Handle during work hours |
+
+#### 5.2 Predefined Alert Rules
+
+**Infrastructure Alerts:**
+- Service health check failure (sustained 1min, `for: 1m`) → P1 (avoids false alerts during rolling deployments)
+- MySQL connection pool usage >80% (sustained 5min) → P2
+- Redis memory >80% → P2
+- JVM heap memory >85% (sustained 5min) → P2
+- Disk usage >90% → P1, >70% → P3
+- CPU >80% sustained 5min → P2
+
+**Business Alerts:**
+- Inbound/outbound order error rate >5% (sustained 5min) → P2
+- Task queue backlog >1000 (sustained 10min) → P2
+- API 5xx error rate >1% (sustained 3min) → P1
+- API P99 latency >5s (sustained 5min) → P2
+
+**Log Alerts (Loki):**
+- ERROR log spike (>50 in 5 minutes) → P2
+- OOM or StackOverflow keywords → P1
+
+#### 5.3 Notification Channel Architecture
+
+```
+AlertManager
+├── Webhook (universal output, any system can integrate)
+├── Email (SMTP configuration)
+├── DingTalk (via prometheus-webhook-dingtalk)
+├── WeCom (via webhook proxy)
+└── Slack (AlertManager native support)
+```
+
+**Alert suppression**: Same alert not repeated within 5 minutes. P1 alerts repeat every 10 minutes until resolved.
+
+### 6. Docker Compose Deployment
+
+#### New Containers
+
+| Component | Image | Port | Memory Limit | Purpose |
+|-----------|-------|------|-------------|---------|
+| Prometheus | `prom/prometheus` | 9090 | 512MB | Metrics storage & query |
+| Grafana | `grafana/grafana` | 3000 | 256MB | Visualization dashboards |
+| Loki | `grafana/loki` | 3100 | 768MB | Log aggregation |
+| Promtail | `grafana/promtail` | — | 128MB | Log collection agent |
+| AlertManager | `prom/alertmanager` | 9093 | 64MB | Alert routing |
+| Node Exporter | `prom/node-exporter` | 9100 | 64MB | Host metrics |
+| MySQL Exporter | `prom/mysqld-exporter` | 9104 | 64MB | MySQL metrics |
+| Redis Exporter | `oliver006/redis_exporter` | 9121 | 64MB | Redis metrics |
+| Kafka Exporter | `danielqsj/kafka-exporter` | 9308 | 64MB | Kafka consumer lag & topic metrics |
+
+**Total additional resources: ~2.0GB memory**
+
+#### Configuration File Structure
+
+```
+monitoring/
+├── prometheus/
+│   ├── prometheus.yml          # Scrape targets & rules
+│   └── alert-rules.yml         # Alert rule definitions
+├── grafana/
+│   ├── provisioning/
+│   │   ├── datasources/        # Auto-register Prometheus + Loki
+│   │   └── dashboards/         # Auto-import dashboards
+│   └── dashboards/
+│       ├── overview.json       # Global overview
+│       ├── jvm.json            # JVM monitoring
+│       ├── business.json       # Business metrics
+│       └── infrastructure.json # Infrastructure
+├── loki/
+│   └── loki-config.yml
+├── promtail/
+│   └── promtail-config.yml
+└── alertmanager/
+    └── alertmanager.yml        # Notification channel config
+```
+
+## Changes to Existing Code
+
+### Backend Changes
+
+1. **`server/build.gradle`**: Add Micrometer Prometheus Registry dependency to all three servers
+2. **New module `modules-utils/monitoring/`**: WesMetrics auto-config, domain event metric listeners
+3. **Gateway `bootstrap.yml`**: Add Actuator endpoint exposure (health, prometheus, info)
+4. **Station `bootstrap.yml`**: Add Actuator endpoint exposure (health, prometheus, info)
+5. **WES `bootstrap.yml`**: Add `prometheus` to existing Actuator endpoint list
+
+### Infrastructure Changes
+
+1. **`docker-compose.yml`**: Add 8 monitoring containers with volume mounts
+2. **`docker-compose.prod.yml`**: Mirror monitoring containers for production
+3. **New `monitoring/` directory**: All monitoring configuration files
+4. **`.github/workflows/deploy.yml`**: Add `monitoring/` directory to SCP deployment
+
+### No Changes Required
+
+- Existing Logback configuration (Promtail reads log files directly)
+- Existing SkyWalking integration (preserved, can coexist)
+- Business domain code (metrics driven by domain events, zero invasion)

--- a/monitoring/alertmanager/alertmanager.yml
+++ b/monitoring/alertmanager/alertmanager.yml
@@ -1,0 +1,46 @@
+global:
+  resolve_timeout: 5m
+
+route:
+  group_by: ["alertname", "severity"]
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 5m
+  receiver: "default"
+  routes:
+    - match:
+        severity: critical
+      receiver: "critical"
+      repeat_interval: 10m
+    - match:
+        severity: warning
+      receiver: "warning"
+    - match:
+        severity: info
+      receiver: "info"
+
+receivers:
+  - name: "default"
+    webhook_configs:
+      - url: "http://localhost:5001/webhook"
+        send_resolved: true
+
+  - name: "critical"
+    webhook_configs:
+      - url: "http://localhost:5001/webhook"
+        send_resolved: true
+
+  - name: "warning"
+    webhook_configs:
+      - url: "http://localhost:5001/webhook"
+        send_resolved: true
+
+  - name: "info"
+    # Info alerts are annotation-only in Grafana, no notification
+
+inhibit_rules:
+  - source_match:
+      severity: "critical"
+    target_match:
+      severity: "warning"
+    equal: ["alertname", "instance"]

--- a/monitoring/grafana/dashboards/business.json
+++ b/monitoring/grafana/dashboards/business.json
@@ -1,0 +1,583 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(wes_inbound_orders_accepted_total[1h])",
+          "legendFormat": "{{warehouse}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Inbound Order Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(wes_outbound_orders_created_total[1h])",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Outbound Order Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(wes_task_picked_total[1h])",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Picking Operations",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 5
+              },
+              {
+                "color": "red",
+                "value": 20
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "increase(wes_task_abnormal_total[24h])",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Task Abnormals (24h)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 8
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(wes_stock_operations_total[1h])) by (type)",
+          "legendFormat": "{{type}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Stock Operations",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 8
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(wes_outbound_waves_created_total[1h])",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Wave Operations",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 39,
+  "tags": [
+    "openwes",
+    "business"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Open WES - Business Metrics",
+  "uid": "openwes-business",
+  "version": 1,
+  "weekStart": ""
+}

--- a/monitoring/grafana/dashboards/infrastructure.json
+++ b/monitoring/grafana/dashboards/infrastructure.json
@@ -1,0 +1,684 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "hikaricp_connections_active",
+          "legendFormat": "{{pool}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "MySQL Connections Active",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(mysql_global_status_queries[5m])",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "MySQL QPS",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 80
+              },
+              {
+                "color": "green",
+                "value": 95
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "redis_keyspace_hits_total / (redis_keyspace_hits_total + redis_keyspace_misses_total) * 100",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Redis Hit Rate",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "redis_memory_used_bytes",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Redis Memory",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 8
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "100 - (avg(rate(node_cpu_seconds_total{mode=\"idle\"}[5m])) * 100)",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "CPU Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 8
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "(1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) * 100",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Memory Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 16
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "(1 - node_filesystem_avail_bytes{fstype!~\"tmpfs|fuse.lxcfs\"} / node_filesystem_size_bytes{fstype!~\"tmpfs|fuse.lxcfs\"}) * 100",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Disk Usage",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "openwes",
+    "infrastructure"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Open WES - Infrastructure",
+  "uid": "openwes-infra",
+  "version": 1,
+  "weekStart": ""
+}

--- a/monitoring/grafana/dashboards/jvm.json
+++ b/monitoring/grafana/dashboards/jvm.json
@@ -1,0 +1,368 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "title": "Heap Memory Used",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "jvm_memory_used_bytes{area=\"heap\", job=~\"$job\"}",
+          "legendFormat": "{{job}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 0 },
+      "id": 2,
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "title": "Non-Heap Memory",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "jvm_memory_used_bytes{area=\"nonheap\", job=~\"$job\"}",
+          "legendFormat": "{{job}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 0 },
+      "id": 3,
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "title": "GC Pause Duration",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(jvm_gc_pause_seconds_sum{job=~\"$job\"}[5m])",
+          "legendFormat": "{{job}} - {{gc}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 8 },
+      "id": 4,
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "title": "GC Count Rate",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(jvm_gc_pause_seconds_count{job=~\"$job\"}[5m])",
+          "legendFormat": "{{job}} - {{gc}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "continuous-GrYlRd" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 200 },
+              { "color": "red", "value": 500 }
+            ]
+          },
+          "mappings": [],
+          "min": 0,
+          "max": 1000
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 8 },
+      "id": 5,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "title": "Thread Count",
+      "type": "gauge",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "jvm_threads_live_threads{job=~\"$job\"}",
+          "legendFormat": "{{job}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 8 },
+      "id": 6,
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "title": "Classes Loaded",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "jvm_classes_loaded_classes{job=~\"$job\"}",
+          "legendFormat": "{{job}}",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": ["openwes", "jvm"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "definition": "label_values(jvm_memory_used_bytes, job)",
+        "hide": 0,
+        "includeAll": true,
+        "multi": true,
+        "name": "job",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(jvm_memory_used_bytes, job)"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Open WES - JVM",
+  "uid": "openwes-jvm",
+  "version": 1,
+  "refresh": "30s"
+}

--- a/monitoring/grafana/dashboards/overview.json
+++ b/monitoring/grafana/dashboards/overview.json
@@ -1,0 +1,313 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "green", "value": 3 }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Services Up",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(up{job=~\"wes-server|station-server|gateway-server\"})",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Active Alerts",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "count(ALERTS{alertstate=\"firing\"})",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Inbound Orders Today",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "increase(wes_inbound_orders_accepted_total[24h])",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Outbound Orders Today",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "increase(wes_outbound_orders_created_total[24h])",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "id": 5,
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "title": "Request Rate",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(rate(http_server_requests_seconds_count[5m])) by (job)",
+          "legendFormat": "{{job}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "id": 6,
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "title": "Error Rate",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(rate(http_server_requests_seconds_count{status=~\"5..\"}[5m])) by (job)",
+          "legendFormat": "{{job}}",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": ["openwes"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "definition": "label_values(up, job)",
+        "hide": 0,
+        "includeAll": true,
+        "multi": true,
+        "name": "job",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(up, job)"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Open WES - Overview",
+  "uid": "openwes-overview",
+  "version": 1,
+  "refresh": "30s"
+}

--- a/monitoring/grafana/provisioning/dashboards/dashboards.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+providers:
+  - name: "Open WES"
+    orgId: 1
+    folder: "Open WES"
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/monitoring/grafana/provisioning/datasources/datasources.yml
+++ b/monitoring/grafana/provisioning/datasources/datasources.yml
@@ -1,0 +1,15 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    editable: false

--- a/monitoring/loki/loki-config.yml
+++ b/monitoring/loki/loki-config.yml
@@ -1,0 +1,44 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  retention_period: 30d
+  per_stream_rate_limit: 3MB
+  per_stream_rate_limit_burst: 15MB
+
+compactor:
+  working_directory: /loki/compactor
+  compaction_interval: 10m
+  retention_enabled: true
+  retention_delete_delay: 2h
+  retention_delete_worker_count: 150
+
+query_range:
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true
+        max_size_mb: 100

--- a/monitoring/prometheus/alert-rules.yml
+++ b/monitoring/prometheus/alert-rules.yml
@@ -1,0 +1,94 @@
+groups:
+  - name: infrastructure
+    rules:
+      # P1: Service health check failure
+      - alert: ServiceDown
+        expr: up == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Service {{ $labels.job }} is down"
+          description: "{{ $labels.instance }} has been unreachable for 1 minute."
+
+      # P1: Disk usage > 90%
+      - alert: DiskSpaceCritical
+        expr: (1 - node_filesystem_avail_bytes{fstype!~"tmpfs|fuse.lxcfs"} / node_filesystem_size_bytes{fstype!~"tmpfs|fuse.lxcfs"}) * 100 > 90
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Disk usage critical on {{ $labels.instance }}"
+          description: "Disk usage is above 90% (current: {{ $value }}%)"
+
+      # P2: CPU > 80% sustained
+      - alert: HighCpuUsage
+        expr: 100 - (avg by(instance) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 80
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High CPU usage on {{ $labels.instance }}"
+          description: "CPU usage above 80% for 5 minutes (current: {{ $value }}%)"
+
+      # P2: JVM heap > 85%
+      - alert: JvmHeapHigh
+        expr: jvm_memory_used_bytes{area="heap"} / jvm_memory_max_bytes{area="heap"} * 100 > 85
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "JVM heap high on {{ $labels.job }}"
+          description: "Heap usage above 85% (current: {{ $value }}%)"
+
+      # P2: MySQL connection pool > 80%
+      - alert: MysqlConnectionPoolHigh
+        expr: hikaricp_connections_active / hikaricp_connections_max * 100 > 80
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "HikariCP connection pool high on {{ $labels.job }}"
+          description: "Active connections above 80% of max (current: {{ $value }}%)"
+
+      # P2: Redis memory > 80%
+      - alert: RedisMemoryHigh
+        expr: redis_memory_used_bytes / redis_memory_max_bytes * 100 > 80
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Redis memory usage high"
+          description: "Redis memory above 80% (current: {{ $value }}%)"
+
+      # P3: Disk > 70%
+      - alert: DiskSpaceWarning
+        expr: (1 - node_filesystem_avail_bytes{fstype!~"tmpfs|fuse.lxcfs"} / node_filesystem_size_bytes{fstype!~"tmpfs|fuse.lxcfs"}) * 100 > 70
+        for: 10m
+        labels:
+          severity: info
+        annotations:
+          summary: "Disk usage elevated on {{ $labels.instance }}"
+          description: "Disk usage above 70% (current: {{ $value }}%)"
+
+  - name: application
+    rules:
+      # P1: 5xx error rate > 1%
+      - alert: HighErrorRate
+        expr: sum(rate(http_server_requests_seconds_count{status=~"5.."}[3m])) / sum(rate(http_server_requests_seconds_count[3m])) * 100 > 1
+        for: 3m
+        labels:
+          severity: critical
+        annotations:
+          summary: "High 5xx error rate on {{ $labels.job }}"
+          description: "5xx error rate above 1% (current: {{ $value }}%)"
+
+      # P2: API P99 latency > 5s
+      - alert: HighApiLatency
+        expr: histogram_quantile(0.99, rate(http_server_requests_seconds_bucket[5m])) > 5
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High API latency on {{ $labels.job }}"
+          description: "P99 latency above 5 seconds (current: {{ $value }}s)"

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,57 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+rule_files:
+  - "alert-rules.yml"
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ["alertmanager:9093"]
+
+scrape_configs:
+  # Application services — 15s interval
+  - job_name: "wes-server"
+    metrics_path: "/actuator/prometheus"
+    scrape_interval: 15s
+    static_configs:
+      - targets: ["wes:9010"]
+
+  - job_name: "station-server"
+    metrics_path: "/actuator/prometheus"
+    scrape_interval: 15s
+    static_configs:
+      - targets: ["station:9040"]
+
+  - job_name: "gateway-server"
+    metrics_path: "/actuator/prometheus"
+    scrape_interval: 15s
+    static_configs:
+      - targets: ["gateway:8090"]
+
+  # Infrastructure exporters — 30s interval
+  - job_name: "mysql"
+    scrape_interval: 30s
+    static_configs:
+      - targets: ["mysql-exporter:9104"]
+
+  - job_name: "redis"
+    scrape_interval: 30s
+    static_configs:
+      - targets: ["redis-exporter:9121"]
+
+  - job_name: "node"
+    scrape_interval: 30s
+    static_configs:
+      - targets: ["node-exporter:9100"]
+
+  - job_name: "kafka"
+    scrape_interval: 30s
+    static_configs:
+      - targets: ["kafka-exporter:9308"]
+
+  # Prometheus self-monitoring
+  - job_name: "prometheus"
+    static_configs:
+      - targets: ["localhost:9090"]

--- a/monitoring/promtail/promtail-config.yml
+++ b/monitoring/promtail/promtail-config.yml
@@ -1,0 +1,49 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: wes-server
+    pipeline_stages:
+      - regex:
+          expression: '(?P<level>DEBUG|INFO|WARN|ERROR)'
+      - labels:
+          level:
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: wes-server
+          __path__: /var/log/wes/*.log
+
+  - job_name: station-server
+    pipeline_stages:
+      - regex:
+          expression: '(?P<level>DEBUG|INFO|WARN|ERROR)'
+      - labels:
+          level:
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: station-server
+          __path__: /var/log/station/*.log
+
+  - job_name: gateway-server
+    pipeline_stages:
+      - regex:
+          expression: '(?P<level>DEBUG|INFO|WARN|ERROR)'
+      - labels:
+          level:
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: gateway-server
+          __path__: /var/log/gateway/*.log

--- a/server/modules-utils/monitoring/build.gradle
+++ b/server/modules-utils/monitoring/build.gradle
@@ -5,6 +5,8 @@ dependencies {
     implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
+    compileOnly project(path: ":modules-wes:wes-api", configuration: 'default')
+    compileOnly project(path: ":modules-station:station-api", configuration: 'default')
     compileOnly 'com.google.guava:guava'
     compileOnly 'org.springframework.boot:spring-boot-starter-web'
 }

--- a/server/modules-utils/monitoring/build.gradle
+++ b/server/modules-utils/monitoring/build.gradle
@@ -1,0 +1,13 @@
+dependencies {
+    implementation project(path: ":modules-utils:common-utils", configuration: 'default')
+    implementation project(path: ":modules-utils:domain-event:domain-event-api", configuration: 'default')
+
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    compileOnly 'com.google.guava:guava'
+    compileOnly 'org.springframework.boot:spring-boot-starter-web'
+}
+
+bootJar { enabled = false }
+jar { enabled = true }

--- a/server/modules-utils/monitoring/src/main/java/org/openwes/monitoring/MonitoringAutoConfiguration.java
+++ b/server/modules-utils/monitoring/src/main/java/org/openwes/monitoring/MonitoringAutoConfiguration.java
@@ -1,0 +1,9 @@
+package org.openwes.monitoring;
+
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+
+@AutoConfiguration
+@ComponentScan(basePackages = "org.openwes.monitoring")
+public class MonitoringAutoConfiguration {
+}

--- a/server/modules-utils/monitoring/src/main/java/org/openwes/monitoring/metrics/InboundMetricsSubscriber.java
+++ b/server/modules-utils/monitoring/src/main/java/org/openwes/monitoring/metrics/InboundMetricsSubscriber.java
@@ -1,0 +1,38 @@
+package org.openwes.monitoring.metrics;
+
+import com.google.common.eventbus.Subscribe;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.RequiredArgsConstructor;
+import org.openwes.wes.api.inbound.event.AcceptOrderCompletionEvent;
+import org.openwes.wes.api.inbound.event.InboundOrderCompletionEvent;
+import org.openwes.wes.api.inbound.event.InboundPlanOrderAcceptedEvent;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class InboundMetricsSubscriber {
+
+    private final MeterRegistry registry;
+
+    @Subscribe
+    public void onAccepted(InboundPlanOrderAcceptedEvent event) {
+        registry.counter("wes.inbound.orders.accepted.total",
+                "warehouse", event.getWarehouseCode() != null ? event.getWarehouseCode() : "unknown")
+                .increment();
+        if (event.getQtyAccepted() != null) {
+            registry.counter("wes.inbound.qty.accepted.total",
+                    "warehouse", event.getWarehouseCode() != null ? event.getWarehouseCode() : "unknown")
+                    .increment(event.getQtyAccepted());
+        }
+    }
+
+    @Subscribe
+    public void onCompleted(InboundOrderCompletionEvent event) {
+        registry.counter("wes.inbound.orders.completed.total").increment();
+    }
+
+    @Subscribe
+    public void onAcceptCompleted(AcceptOrderCompletionEvent event) {
+        registry.counter("wes.inbound.accept.completed.total").increment();
+    }
+}

--- a/server/modules-utils/monitoring/src/main/java/org/openwes/monitoring/metrics/OutboundMetricsSubscriber.java
+++ b/server/modules-utils/monitoring/src/main/java/org/openwes/monitoring/metrics/OutboundMetricsSubscriber.java
@@ -1,0 +1,49 @@
+package org.openwes.monitoring.metrics;
+
+import com.google.common.eventbus.Subscribe;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.RequiredArgsConstructor;
+import org.openwes.wes.api.outbound.event.OutboundPlanOrderCompletionEvent;
+import org.openwes.wes.api.outbound.event.OutboundPlanOrderCreatedEvent;
+import org.openwes.wes.api.outbound.event.OutboundWaveCompletionEvent;
+import org.openwes.wes.api.outbound.event.OutboundWaveCreatedEvent;
+import org.openwes.wes.api.outbound.event.PickingOrderCompletionEvent;
+import org.openwes.wes.api.outbound.event.PickingOrderDispatchedEvent;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OutboundMetricsSubscriber {
+
+    private final MeterRegistry registry;
+
+    @Subscribe
+    public void onOrderCreated(OutboundPlanOrderCreatedEvent event) {
+        registry.counter("wes.outbound.orders.created.total").increment();
+    }
+
+    @Subscribe
+    public void onOrderCompleted(OutboundPlanOrderCompletionEvent event) {
+        registry.counter("wes.outbound.orders.completed.total").increment();
+    }
+
+    @Subscribe
+    public void onPickingDispatched(PickingOrderDispatchedEvent event) {
+        registry.counter("wes.outbound.picking.dispatched.total").increment();
+    }
+
+    @Subscribe
+    public void onPickingCompleted(PickingOrderCompletionEvent event) {
+        registry.counter("wes.outbound.picking.completed.total").increment();
+    }
+
+    @Subscribe
+    public void onWaveCreated(OutboundWaveCreatedEvent event) {
+        registry.counter("wes.outbound.waves.created.total").increment();
+    }
+
+    @Subscribe
+    public void onWaveCompleted(OutboundWaveCompletionEvent event) {
+        registry.counter("wes.outbound.waves.completed.total").increment();
+    }
+}

--- a/server/modules-utils/monitoring/src/main/java/org/openwes/monitoring/metrics/StockMetricsSubscriber.java
+++ b/server/modules-utils/monitoring/src/main/java/org/openwes/monitoring/metrics/StockMetricsSubscriber.java
@@ -1,0 +1,33 @@
+package org.openwes.monitoring.metrics;
+
+import com.google.common.eventbus.Subscribe;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.RequiredArgsConstructor;
+import org.openwes.wes.api.stock.event.StockClearEvent;
+import org.openwes.wes.api.stock.event.StockCreateEvent;
+import org.openwes.wes.api.stock.event.StockTransferEvent;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class StockMetricsSubscriber {
+
+    private final MeterRegistry registry;
+
+    @Subscribe
+    public void onStockCreated(StockCreateEvent event) {
+        registry.counter("wes.stock.operations.total", "type", "create").increment();
+    }
+
+    @Subscribe
+    public void onStockTransferred(StockTransferEvent event) {
+        registry.counter("wes.stock.operations.total", "type", "transfer",
+                "taskType", event.getTaskType() != null ? event.getTaskType().name() : "unknown")
+                .increment();
+    }
+
+    @Subscribe
+    public void onStockCleared(StockClearEvent event) {
+        registry.counter("wes.stock.operations.total", "type", "clear").increment();
+    }
+}

--- a/server/modules-utils/monitoring/src/main/java/org/openwes/monitoring/metrics/TaskMetricsSubscriber.java
+++ b/server/modules-utils/monitoring/src/main/java/org/openwes/monitoring/metrics/TaskMetricsSubscriber.java
@@ -1,0 +1,31 @@
+package org.openwes.monitoring.metrics;
+
+import com.google.common.eventbus.Subscribe;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.RequiredArgsConstructor;
+import org.openwes.wes.api.task.event.OperationTaskAbnormalEvent;
+import org.openwes.wes.api.task.event.OperationTaskPickedEvent;
+import org.openwes.wes.api.task.event.TransferContainerSealedEvent;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TaskMetricsSubscriber {
+
+    private final MeterRegistry registry;
+
+    @Subscribe
+    public void onTaskPicked(OperationTaskPickedEvent event) {
+        registry.counter("wes.task.picked.total").increment();
+    }
+
+    @Subscribe
+    public void onTaskAbnormal(OperationTaskAbnormalEvent event) {
+        registry.counter("wes.task.abnormal.total").increment();
+    }
+
+    @Subscribe
+    public void onContainerSealed(TransferContainerSealedEvent event) {
+        registry.counter("wes.task.container.sealed.total").increment();
+    }
+}

--- a/server/modules-utils/monitoring/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/server/modules-utils/monitoring/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+org.openwes.monitoring.MonitoringAutoConfiguration

--- a/server/server/gateway-server/build.gradle
+++ b/server/server/gateway-server/build.gradle
@@ -9,6 +9,9 @@ dependencies {
     implementation 'org.apache.skywalking:apm-toolkit-logback-1.x'
     implementation 'org.springframework.cloud:spring-cloud-starter-loadbalancer'
 
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation project(path: ":modules-utils:monitoring", configuration: 'default')
+
 }
 
 test {

--- a/server/server/gateway-server/src/main/resources/bootstrap.yml
+++ b/server/server/gateway-server/src/main/resources/bootstrap.yml
@@ -19,3 +19,15 @@ spring:
 
 server:
   port: 8090
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include:
+          - health
+          - info
+          - prometheus
+  endpoint:
+    health:
+      show-details: always

--- a/server/server/station-server/build.gradle
+++ b/server/server/station-server/build.gradle
@@ -13,6 +13,9 @@ dependencies {
     implementation 'org.apache.skywalking:apm-toolkit-logback-1.x'
 
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui'
+
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation project(path: ":modules-utils:monitoring", configuration: 'default')
 }
 
 test {

--- a/server/server/station-server/src/main/resources/bootstrap.yml
+++ b/server/server/station-server/src/main/resources/bootstrap.yml
@@ -26,3 +26,15 @@ pf4j:
 
 worker:
   id: 1
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include:
+          - health
+          - info
+          - prometheus
+  endpoint:
+    health:
+      show-details: always

--- a/server/server/wes-server/build.gradle
+++ b/server/server/wes-server/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     implementation project(path: ":modules-wes:wes-stocktake", configuration: 'default')
     implementation project(path: ":modules-ai:ai-core", configuration: 'default')
     implementation project(path: ":modules-plugin:plugin-sdk", configuration: 'default')
+    implementation project(path: ":modules-utils:monitoring", configuration: 'default')
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'

--- a/server/server/wes-server/src/main/resources/bootstrap.yml
+++ b/server/server/wes-server/src/main/resources/bootstrap.yml
@@ -73,6 +73,7 @@ management:
           - env
           - scheduledtasks
           - threadpool
+          - prometheus
 
   endpoint:
     health:

--- a/server/server/wes-server/src/main/resources/db/changelog/db.changelog-20260523.xml
+++ b/server/server/wes-server/src/main/resources/db/changelog/db.changelog-20260523.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+
+    <!-- Add Monitoring app and its menu entries -->
+    <changeSet id="add_monitoring_app_menus" author="dev">
+        <preConditions onFail="MARK_RAN">
+            <and>
+                <tableExists tableName="u_menu"/>
+                <sqlCheck expectedResult="0">
+                    SELECT COUNT(*) FROM u_menu WHERE system_code = 'monitoring' AND parent_id = 0
+                </sqlCheck>
+            </and>
+        </preConditions>
+        <sql>
+            -- Top-level monitoring app (type=1: System)
+            INSERT INTO u_menu (id, create_user, system_code, parent_id, type, title, description, permissions, order_num, icon, path, enable, create_time, update_time, update_user, iframe_show)
+            VALUES (1300000000, 'admin', 'monitoring', 0, 1, 'monitoring.app.title', NULL, 'monitoring', 5, 'chart', '/monitoring', 1, UNIX_TIMESTAMP()*1000, UNIX_TIMESTAMP()*1000, 'admin', 0);
+
+            -- Overview dashboard (type=2: Menu)
+            INSERT INTO u_menu (id, create_user, system_code, parent_id, type, title, description, permissions, order_num, icon, path, enable, create_time, update_time, update_user, iframe_show)
+            VALUES (1301000000, 'admin', 'monitoring', 1300000000, 2, 'monitoring.overview.title', NULL, '/monitoring/overview', 1, 'dashboard', '/monitoring/overview', 1, UNIX_TIMESTAMP()*1000, UNIX_TIMESTAMP()*1000, 'admin', 0);
+
+            -- JVM monitoring (type=2: Menu)
+            INSERT INTO u_menu (id, create_user, system_code, parent_id, type, title, description, permissions, order_num, icon, path, enable, create_time, update_time, update_user, iframe_show)
+            VALUES (1302000000, 'admin', 'monitoring', 1300000000, 2, 'monitoring.jvm.title', NULL, '/monitoring/jvm', 2, NULL, '/monitoring/jvm', 1, UNIX_TIMESTAMP()*1000, UNIX_TIMESTAMP()*1000, 'admin', 0);
+
+            -- Business metrics (type=2: Menu)
+            INSERT INTO u_menu (id, create_user, system_code, parent_id, type, title, description, permissions, order_num, icon, path, enable, create_time, update_time, update_user, iframe_show)
+            VALUES (1303000000, 'admin', 'monitoring', 1300000000, 2, 'monitoring.business.title', NULL, '/monitoring/business', 3, NULL, '/monitoring/business', 1, UNIX_TIMESTAMP()*1000, UNIX_TIMESTAMP()*1000, 'admin', 0);
+
+            -- Infrastructure (type=2: Menu)
+            INSERT INTO u_menu (id, create_user, system_code, parent_id, type, title, description, permissions, order_num, icon, path, enable, create_time, update_time, update_user, iframe_show)
+            VALUES (1304000000, 'admin', 'monitoring', 1300000000, 2, 'monitoring.infrastructure.title', NULL, '/monitoring/infrastructure', 4, NULL, '/monitoring/infrastructure', 1, UNIX_TIMESTAMP()*1000, UNIX_TIMESTAMP()*1000, 'admin', 0);
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/server/server/wes-server/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/server/server/wes-server/src/main/resources/db/changelog/db.changelog-master.xml
@@ -26,5 +26,6 @@
     <include file="/db/changelog/db.changelog-20260317.xml"/>
     <include file="/db/changelog/db.changelog-20260517.xml"/>
     <include file="/db/changelog/db.changelog-20260521.xml"/>
+    <include file="/db/changelog/db.changelog-20260523.xml"/>
 
 </databaseChangeLog>

--- a/server/settings.gradle
+++ b/server/settings.gradle
@@ -44,6 +44,7 @@ include 'modules-utils:common-import'
 include 'modules-utils:distribute-scheduler'
 include 'modules-utils:domain-event:domain-event-api'
 include 'modules-utils:domain-event:domain-event-core'
+include 'modules-utils:monitoring'
 
 include 'server:station-server'
 include 'server:gateway-server'


### PR DESCRIPTION
  ## Summary

  - Add full monitoring infrastructure: Prometheus, Grafana, Loki, Promtail, AlertManager with Docker Compose integration
  - Add monitoring Spring Boot module (modules-utils/monitoring) with Micrometer Prometheus registry and domain event metrics subscribers (Inbound, Outbound, Task, Stock)
  - Add Grafana dashboards (Overview, JVM, Business, Infrastructure) with frontend pages embedding Grafana via iframe
  - Add alert rules (Prometheus + Loki) and AlertManager severity-based routing
  - Add monitoring app menu entries via Liquibase migration and i18n support
  - Refactor server/Code Rule.md → docs/standards/backend.md for consistency with other standards docs

  ## Test plan

  - [ ] Verify docker-compose up starts all monitoring services
  - [ ] Verify /actuator/prometheus endpoint exposes metrics on all servers
  - [ ] Verify Grafana dashboards load correctly
  - [ ] Verify monitoring frontend pages render Grafana iframes
  - [ ] Verify alert rules trigger and route through AlertManager
  - [ ] Verify domain event metrics are recorded on business operations
